### PR TITLE
Extend short captions to include tables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/martisak/pandoc-shortcaption.svg?branch=master)](https://travis-ci.org/martisak/pandoc-shortcaption) [![PyPI version](https://badge.fury.io/py/pandoc-shortcaption.svg)](https://badge.fury.io/py/pandoc-shortcaption)
 
-`pandoc-shortcaption` is a [pandoc](http://pandoc.org/) filter for adding short captions to images in LaTeX output, i.e. `\caption[Short caption]{Long caption}`.
+`pandoc-shortcaption` is a [pandoc](http://pandoc.org/) filter for adding short captions to images in LaTeX output, i.e. `\caption[Short caption]{Long caption}`. For images, the alternate text is used to generate the short caption, but for tables the first sentence is used.
 
 ## Installation
 

--- a/pandoc_shortcaption/__main__.py
+++ b/pandoc_shortcaption/__main__.py
@@ -47,7 +47,7 @@ def shortcap(key, value, format, meta):
 
         if (alt != ""):
 
-            caption = " ".join([c['c'] for c in value[1] if c['t'] == "Str"])
+            caption = text(value[1])
 
             raw = r'\begin{figure}[htbp]' + '\n'
             raw += r'\centering' + '\n'

--- a/pandoc_shortcaption/__main__.py
+++ b/pandoc_shortcaption/__main__.py
@@ -1,6 +1,6 @@
 #!/bin/env /home/eisamar/.virtualenvs/pandoc-shortcaption/bin/python
 
-from pandocfilters import toJSONFilter, RawInline
+from pandocfilters import toJSONFilter, RawInline, RawBlock
 import logging
 FORMAT = "%(asctime)s %(levelname)-8s%(module)-10s %(message)s"
 logging.basicConfig(format=FORMAT, level=logging.ERROR)
@@ -15,6 +15,18 @@ def remove_prefix(text, prefix):
     if text.startswith(prefix):
         return text[len(prefix):]
     return text  # or whatever
+
+def text(c):
+    if type(c) == list:
+        return ' '.join(text(d) for d in c)
+    elif c['t'] == 'Str':
+        return c['c'].replace('{','\\{').replace('}','\\}')
+    elif c['t'] == 'RawInline':
+        return c['c'][1]
+    elif c['t'] == 'Math':
+        return '$'+c['c'][1]+'$'
+    else:
+        return ' '.join(text(d) for d in c['c'])
 
 def shortcap(key, value, format, meta):
 
@@ -52,6 +64,22 @@ def shortcap(key, value, format, meta):
 
             return RawInline('tex', raw)
 
+    if key == "Table" and format == "latex":
+        caption = text(value[0])
+        short = caption.split('.')[0]+'.'
+        raw = "\\begin{longtable}[]{@{}ll@{}}\n"
+        raw += "\\caption[{}]{{{}}}".format(short,caption)
+        raw += '\\tabularnewline\n \\toprule\n'
+        raw += ' & '.join(text(l) for l in value[3])
+        raw += "\\tabularnewline\n \\midrule \\endfirsthead \\toprule\n"
+        raw += ' & '.join(text(l) for l in value[3])
+        raw += "\\tabularnewline\n \\midrule \\endhead\n"
+        for line in value[4]:
+            raw += ' & '.join(text(column) for column in line)
+            raw += '\\tabularnewline\n'
+        raw += '\\bottomrule \\end{longtable}'
+        
+        return RawBlock('tex',raw)
 
 def main():
     toJSONFilter(shortcap)


### PR DESCRIPTION
Nothing fancy about this; it just creates the output that pandoc usually produces for tables but generates a short caption by taking the first sentence of the description. I have not tested it extensively; it works for my scenario, so I figured I would contribute it.